### PR TITLE
Add page export/import support

### DIFF
--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -272,6 +272,9 @@
 
         pages        (:pages data)
         pages-index  (:pages-index data)
+        page-set     (some-> (::page-ids cfg) set)
+        pages        (if page-set (vec (filter page-set pages)) pages)
+        pages-index  (if page-set (select-keys pages-index page-set) pages-index)
 
         thumbnails   (bfc/get-file-object-thumbnails cfg file-id)]
 
@@ -659,20 +662,23 @@
        (not-empty)))
 
 (defn- read-file-pages
-  [{:keys [::bfc/input ::file-id ::entries] :as cfg}]
-  (->> (keep (match-page-entry-fn file-id) entries)
-       (keep (fn [{:keys [id entry]}]
-               (let [page (->> (read-entry input entry)
-                               (decode-page))
-                     page (dissoc page :options)]
-                 (when (= id (:id page))
-                   (let [objects (-> (assoc cfg ::page-id id)
-                                     (read-file-shapes))]
-                     (assoc page :objects objects))))))
-       (sort-by :index)
-       (reduce (fn [result {:keys [id] :as page}]
-                 (assoc result id (dissoc page :index)))
-               (d/ordered-map))))
+  [{:keys [::bfc/input ::file-id ::entries ::page-ids] :as cfg}]
+  (let [page-set (some-> page-ids set)]
+    (->> (keep (match-page-entry-fn file-id) entries)
+         (filter (fn [{:keys [id]}]
+                   (or (nil? page-set) (contains? page-set id))))
+         (keep (fn [{:keys [id entry]}]
+                 (let [page (->> (read-entry input entry)
+                                 (decode-page))
+                       page (dissoc page :options)]
+                   (when (= id (:id page))
+                     (let [objects (-> (assoc cfg ::page-id id)
+                                       (read-file-shapes))]
+                       (assoc page :objects objects))))))
+         (sort-by :index)
+         (reduce (fn [result {:keys [id] :as page}]
+                   (assoc result id (dissoc page :index)))
+                 (d/ordered-map)))))
 
 (defn- read-file-thumbnails
   [{:keys [::bfc/input ::file-id ::entries] :as cfg}]
@@ -1029,3 +1035,15 @@
                 :id (str id)
                 :elapsed (dt/format-duration (tp))
                 :error? (some? @cs))))))
+
+(defn read-page!
+  "Read the first page from a binfile without persisting it."
+  [input]
+  (with-open [input (ZipFile. (fs/file input))]
+    (let [manifest (read-manifest input)
+          file-id  (:id (first (:files manifest)))
+          entries  (read-zip-entries input)
+          pages    (read-file-pages {::bfc/input input
+                                     ::file-id file-id
+                                     ::entries entries})]
+      (-> pages vals first)))

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -20,8 +20,9 @@
    [app.loggers.webhooks :as-alias webhooks]
    [app.media :as media]
    [app.rpc :as-alias rpc]
-   [app.rpc.commands.files :as files]
-   [app.rpc.commands.projects :as projects]
+  [app.rpc.commands.files :as files]
+  [app.rpc.commands.files_update :as files.update]
+  [app.rpc.commands.projects :as projects]
    [app.rpc.commands.teams :as teams]
    [app.rpc.doc :as-alias doc]
    [app.tasks.file-gc]
@@ -39,6 +40,15 @@
   schema:export-binfile
   [:map {:title "export-binfile"}
    [:file-id ::sm/uuid]
+   [:version {:optional true} ::sm/int]
+   [:include-libraries ::sm/boolean]
+   [:embed-assets ::sm/boolean]])
+
+(def ^:private
+  schema:export-page-binfile
+  [:map {:title "export-page-binfile"}
+   [:file-id ::sm/uuid]
+   [:page-id ::sm/uuid]
    [:version {:optional true} ::sm/int]
    [:include-libraries ::sm/boolean]
    [:embed-assets ::sm/boolean]])
@@ -73,6 +83,23 @@
                 :file-id (str file-id)
                 :cause cause))))))
 
+(defn stream-export-page-v3
+  [cfg {:keys [file-id page-id include-libraries embed-assets] :as params}]
+  (yres/stream-body
+   (fn [_ output-stream]
+     (try
+       (-> cfg
+           (assoc ::bfc/ids #{file-id})
+           (assoc ::bfc/page-ids #{page-id})
+           (assoc ::bfc/embed-assets embed-assets)
+           (assoc ::bfc/include-libraries include-libraries)
+           (bf.v3/export-files! output-stream))
+       (catch Throwable cause
+         (l/err :hint "exception on exporting page"
+                :file-id (str file-id)
+                :page-id (str page-id)
+                :cause cause))))))
+
 (sv/defmethod ::export-binfile
   "Export a penpot file in a binary format."
   {::doc/added "1.15"
@@ -87,6 +114,22 @@
                     2 (throw (ex-info "not-implemented" {}))
                     3 (stream-export-v3 cfg params))]
 
+      {::yres/status 200
+       ::yres/headers {"content-type" "application/octet-stream"}
+       ::yres/body body})))
+
+(sv/defmethod ::export-page-binfile
+  "Export a single page in a binary format."
+  {::doc/added "1.20"
+   ::webhooks/event? true
+   ::sm/params schema:export-page-binfile}
+  [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id page-id version] :as params}]
+  (files/check-read-permissions! pool profile-id file-id)
+  (fn [_]
+    (let [version (or version 3)
+          body    (case (int version)
+                    3 (stream-export-page-v3 cfg params)
+                    (throw (ex-info "not-implemented" {})))]
       {::yres/status 200
        ::yres/headers {"content-type" "application/octet-stream"}
        ::yres/body body})))
@@ -126,6 +169,12 @@
            [:map-of ::sm/uuid [:string {:max 250}]]]]
    [:project-id ::sm/uuid]
    [:version {:optional true} ::sm/int]
+  [:file ::media/upload]])
+
+(def ^:private schema:import-page-binfile
+  [:map {:title "import-page-binfile"}
+   [:file-id ::sm/uuid]
+   [:page-id ::sm/uuid]
    [:file ::media/upload]])
 
 (sv/defmethod ::import-binfile
@@ -142,3 +191,37 @@
     (with-meta
       (sse/response (partial import-binfile cfg params))
       {::audit/props {:file nil}})))
+
+(defn- import-page-binfile*
+  [{:keys [::db/pool] :as cfg} {:keys [profile-id file-id page-id file]}]
+  (let [page (bf.v3/read-page! (:path file))
+        cfg  (assoc cfg ::rpc/profile-id profile-id)]
+    (files.update/update-file! cfg file-id
+      (fn [_ file]
+        (let [page' (-> page
+                         (assoc :id page-id)
+                         (update :objects (fn [objs]
+                                            (reduce-kv (fn [m id obj]
+                                                         (assoc m id (assoc obj :page-id page-id)))
+                                                       {}
+                                                       objs))))]
+          (update file :data
+                  (fn [data]
+                    (let [idx (.indexOf (:pages data) page-id)
+                          idx (if (neg? idx) (count (:pages data)) idx)]
+                      (-> data
+                          (assoc-in [:pages-index page-id] page')
+                          (update :pages (fn [p]
+                                           (if (>= idx (count p))
+                                             (conj p page-id)
+                                             (assoc p idx page-id))))))))))))
+
+(sv/defmethod ::import-page-binfile
+  "Import a single page into an existing file."
+  {::doc/added "1.20"
+   ::webhooks/event? true
+   ::sm/params schema:import-page-binfile}
+  [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id page-id] :as params}]
+  (files/check-edition-permissions! pool profile-id file-id)
+  (import-page-binfile* cfg (assoc params :profile-id profile-id))
+  {:page-id page-id})

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -106,3 +106,25 @@
                      (v3/import-files!))]
       (t/is (= (count result) 1))
       (t/is (every? uuid? result)))))
+
+(t/deftest export-page-binfile-v3
+  (let [profile (th/create-profile* 1)
+        file    (prepare-simple-file profile)
+        page-id (uuid/custom 1 1)
+        other-id (uuid/custom 1 2)
+        output  (tmp/tempfile :suffix ".zip")]
+
+    (v3/export-files!
+     (-> th/*system*
+         (assoc ::bfc/ids #{(:id file)})
+         (assoc ::bfc/page-ids #{page-id})
+         (assoc ::bfc/embed-assets false)
+         (assoc ::bfc/include-libraries false))
+     (io/output-stream output))
+
+    (with-open [zip (java.util.zip.ZipFile. (fs/file output))]
+      (let [names (into #{} (map #(.getName %) (enumeration-seq (.entries zip))))
+            path1 (str "files/" (:id file) "/pages/" page-id ".json")
+            path2 (str "files/" (:id file) "/pages/" other-id ".json")]
+        (t/is (contains? names path1))
+        (t/is (not (contains? names path2))))))


### PR DESCRIPTION
## Summary
- allow passing `::page-ids` to binfile v3 export/import helpers
- expose helper `read-page!` for loading a page from an archive
- implement RPC commands `export-page-binfile` and `import-page-binfile`
- test exporting a single page

## Testing
- `yarn install` *(backend)*
- `clojure -M:dev:test --reporter kaocha.report/documentation` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a949f72188327b775c646a3f769ef